### PR TITLE
feat: enable cloud logging manually

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,18 +1,4 @@
 steps:
-  # Temporarily disable kaniko cache approach due to unexpected build errors.
-  #
-  # build docker image for target sub-pacakge
-  # use debug tag so that we can use `sh` entrypoint
-  #- name: 'gcr.io/kaniko-project/executor:debug'
-  #  id: Build Image
-  #  entrypoint: 'sh'
-  #  args:
-  #    - '-c'
-  #    - |
-  #      cp yarn.lock packages/$_TARGET_PACKAGE
-  #      cd packages/$_TARGET_PACKAGE
-  #      /kaniko/executor --context="$(pwd)" --cache=true --cache-ttl=48h --destination=gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA}
-
   # Pull previous image
   - name: gcr.io/cloud-builders/docker
     args:
@@ -30,11 +16,8 @@ steps:
         cd packages/$_TARGET_PACKAGE
 
         docker build -t \
-
         gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA} \
-
         -t gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest \
-
         --cache-from gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest .
     entrypoint: bash
 
@@ -44,7 +27,6 @@ steps:
       - push
       - 'gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA}'
 
-
   # Deploy container image to Cloud Runs
   - name: gcr.io/cloud-builders/gcloud
     id: Deploy Image
@@ -52,16 +34,13 @@ steps:
     args:
       - '-c'
       - |
-
         # read cloud run service names from substitution variable
         IFS=',' read -r -a cloud_runs <<< "$_CLOUD_RUN_SERVICE_NAMES"
 
         for cr in "${cloud_runs[@]}"
         do
-
-        # deploy cloud run service iteratively
-        gcloud run deploy "$cr" --image gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA} --region asia-east1
-
+          # deploy cloud run service iteratively
+          gcloud run deploy "$cr" --image gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA} --region asia-east1
         done
 
   # Push container image to registry to update the latest one
@@ -71,6 +50,9 @@ steps:
       - 'gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest'
 
 timeout: 2400s
+
+options:
+  logging: CLOUD_LOGGING_ONLY
 
 substitutions:
   _TARGET_PACKAGE: '' # default value


### PR DESCRIPTION
因為[此項變動](https://cloud.google.com/build/docs/cloud-build-service-account-updates?hl=zh-tw&_gl=1*1tlq8o9*_ga*MTI3NTMzMjQ1Ny4xNzQ2NDI3NTk2*_ga_WH2QY8WWF5*czE3NDkzNTM3MzAkbzE5JGcxJHQxNzQ5MzU0NTIxJGo2MCRsMCRoMA..#disable-sa)，建立 cloud build 時需要指定 service account。因上述原因，還需要指定 logging option。